### PR TITLE
now works with a saved metric via settings svc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,6 @@ FROM golang:1.19.2-alpine
 
 COPY main.go /main.go
 WORKDIR /
-RUN go mod init  hpa-example
-RUN go get github.com/prometheus/client_golang/prometheus
-RUN go get github.com/prometheus/client_golang/prometheus/collectors
-RUN go get github.com/prometheus/client_golang/prometheus/promauto
-RUN go get github.com/prometheus/client_golang/prometheus/promhttp
 RUN go build /main.go
 EXPOSE 8000:8000
 ENTRYPOINT go run /main.go

--- a/main.go
+++ b/main.go
@@ -32,8 +32,8 @@ type ExampleMetricResponse struct {
 
 func getMetric(w http.ResponseWriter, req *http.Request) {
 	// pull metric from Settings service
-	resp, err := http.Get("http://earth.ppstaging.net/flyer/api/settings/hpa-example")
-	// resp, err := http.Get("http://settings/settings/hpa-example")
+	// resp, err := http.Get("http://earth.ppstaging.net/flyer/api/settings/hpa-example")
+	resp, err := http.Get("http://settings/settings/hpa-example")
 
 	if err != nil {
 		fmt.Println("error fetching from settings service")


### PR DESCRIPTION
**NOTE:** an image created from this branch has already been built and pushed to:
`quay.io/paperlesspost/hpa-example:configurable-metric`

## Instructions for use on `earth`

1. Generate an authentication token (might need to be refreshed every 5~ minutes)
```
export AUTH_TOKEN="$(curl -d '{"email_address" : "dcosgrove@paperlesspost.com", "password" : "Stampy"}' https://earth.ppstaging.net/flyer/api/auth/login |jq -r '.data.id_token' -)"
```

2. Change example_metric (you can change this value from 10 to whatever you want)
```
curl -X PUT -H "Content-Type: application/json" -H "Authorization: Bearer $AUTH_TOKEN" -d '{"settings": { "example_metric": { "value": 10 }}}' https://earth.ppstaging.net/flyer/api/settings/hpa-example
Get the metric via hpa-example pods running on earth
```

## Sample response


Sample metrics response from `/metrics':
```
$ curl localhost:8000/metrics            
# HELP example_metric Custom arbitrary value to test example HPA
# TYPE example_metric gauge
example_metric 10
```